### PR TITLE
Pinned Table Column Overlays Horizontal Scrollbar

### DIFF
--- a/responsive-tables.css
+++ b/responsive-tables.css
@@ -22,7 +22,7 @@ table td, table th { padding: 9px 10px; text-align: left; }
 	
 	table.responsive { margin-bottom: 0; }
 	
-	.pinned { position: absolute; left: 0; top: 0; background: #fff; width: 35%; overflow: hidden; overflow-x: scroll; border-right: 1px solid #ccc; border-left: 1px solid #ccc; }
+	.pinned { height: 98%; position: absolute; left: 0; top: 0; background: #fff; width: 35%; overflow: hidden; overflow-x: scroll; border-right: 1px solid #ccc; border-left: 1px solid #ccc; }
 	.pinned table { border-right: none; border-left: none; width: 100%; }
 	.pinned table th, .pinned table td { white-space: nowrap; }
 	.pinned td:last-child { border-bottom: 0; }


### PR DESCRIPTION
This is a hackish 'solution' (for lack of a better word) to the pinned column overlaying the scrollbar issue. 

The problem seems to be poor handling of white-space:nowrap by browsers. 

Both the pinned and primary tables should have rows of the same height, but, when there is overflow in the primary table, its row gets a tiny bit taller. Depending on how many rows are in the table, the net result is a difference in height between the .pinned table (which is slightly shorter) and the data table (which is slightly longer). The net result is that the bottom of .pinned table appears where the scrollbar is displayed for the data table, giving the appearance of overlaying the scroll bar.  

From my testing and playing around with this problem, it appears to me that the Zurb CSS is appropriate -- in cases where one would expect it -- there is white-space: nowrap. I believe this is a problem with browsers, hopefully one that will go away as everyone gets more experience with mobile devices.

For now, I'm adding this little act to my CSS to set .pinned to a height of 98%. Even though it does not fix the problem of the row height differences, it does seem to move the bottom of the .pinned table out of the way of the scroll bar. 

In my opinion, users are less likely to assume there is an error with the scroll bar displaying properly.

But, it's a hack. I'll deny I recommended it, if asked later. ;-)

I believe this could address the 2nd part of the issue reported here https://github.com/zurb/responsive-tables/issues/5

Thanks for sharing this work, it's very helpful.
