### PR TITLE
Scrollable visual cue solution?

### DIFF
--- a/responsive-tables.css
+++ b/responsive-tables.css
@@ -27,7 +27,9 @@ table td, table th { padding: 9px 10px; text-align: left; }
 	.pinned table th, .pinned table td { white-space: nowrap; }
 	.pinned td:last-child { border-bottom: 0; }
 	
-	div.table-wrapper { position: relative; margin-bottom: 20px; overflow: hidden; border-right: 1px solid #ccc; }
+	.pseudo-wrapper::before { content:"Scroll for More >>"; float:right; font-size:11px; opacity:0.5; color:#800; } /* Scroll prompt text/position/style */
+	
+	div.table-wrapper { position: relative; margin-bottom: 20px; overflow: hidden; border-right: 1px solid #ccc; clear:both; }
 	div.table-wrapper div.scrollable table { margin-left: 35%; }
 	div.table-wrapper div.scrollable { overflow: scroll; overflow-y: hidden; }	
 	

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -22,6 +22,7 @@ $(document).ready(function() {
 	
 	function splitTable(original)
 	{
+		original.wrap("<span class='pseudo-wrapper' />");
 		original.wrap("<div class='table-wrapper' />");
 		
 		var copy = original.clone();
@@ -37,6 +38,7 @@ $(document).ready(function() {
     original.closest(".table-wrapper").find(".pinned").remove();
     original.unwrap();
     original.unwrap();
+	original.unwrap();
 	}
 
 });


### PR DESCRIPTION
I agree with issue # 2's author. It would be nice if there was come sort of visual cue to let users know that they can scroll to see more of the responsive table.

I took a stab at a more permanent solution to this by wrapping `<div class="table-wrapper">` in a `<span>` which has some prompt text defined in a ::before pseudo element. Adds a tiny bit of markup, but it seems like the most flexible solution to me.

Great tool, by the way!
