### PR TITLE
Fix double-tables in FF near responsive boundary

### DIFF
--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -1,14 +1,20 @@
 $(document).ready(function() {
   var switched = false;
   var updateTables = function() {
-    if (($(window).width() < 767) && !switched ){
+    var mediaQueryWidth = 767;
+    var scrollBarWidth = 0;
+
+    if ($.browser.mozilla)
+      scrollBarWidth = window.innerWidth - jQuery("body").width();
+
+    if (($(window).width() < mediaQueryWidth - scrollBarWidth) && !switched ){
       switched = true;
       $("table.responsive").each(function(i, element) {
         splitTable($(element));
       });
       return true;
     }
-    else if (switched && ($(window).width() > 767)) {
+    else if (switched && ($(window).width() > mediaQueryWidth - scrollBarWidth)) {
       switched = false;
       $("table.responsive").each(function(i, element) {
         unsplitTable($(element));


### PR DESCRIPTION
FireFox calculates window width differently in media queries than it does in JavaScript.  When responsive tables is viewed in FireFox at window widths near the responsive cut-off (ex: 768px), double tables can appear because the JavaScript has cloned the table in the HTML but the media query selectors haven't kicked in.
