### PR TITLE
Adding a "redraw" event to the JS for use with AJAX apps (instead of "load" / "resize")

### DIFF
--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -17,7 +17,8 @@ $(document).ready(function() {
   };
    
   $(window).load(updateTables);
-  $(window).bind("resize", updateTables);
+  $(window).on("redraw",function(){switched=false;updateTables();}); // An event to listen for
+  $(window).on("resize", updateTables);
    
 	
 	function splitTable(original)


### PR DESCRIPTION
The "on" syntax is really more stylistic. This is what we did (and tested) in our implementation so I've left it intact here. But the significant it is allowing for a "redraw" event to be handled. 

We're using responsive tables on an app that redraws all its pages primarily using AJAX. No new load meant that new tables weren't acting responsively. Rather than an ugly hack we added this one event, allowing us to simply do a $(document).trigger('redraw') call at the end of our AJAX load+redraw function and the tables look pretty — on first load or after an AJAX load. So it all works as originally intended with the extra benefit of being an easy fix for AJAX patterns.
