### PR TITLE
Fixing row height when cloning the original table

### DIFF
--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -34,6 +34,7 @@ $(document).ready(function() {
 		original.wrap("<div class='scrollable' />");
 
     setCellHeights(original, copy);
+    setTableHeights(original, copy);
 	}
 	
 	function unsplitTable(original) {
@@ -50,6 +51,14 @@ $(document).ready(function() {
       $('th,td', original).css('height', height+'px');
       $('th,td', copy).css('height', height+'px');
     });
+  }
+
+  function setTableHeights(original, copy) {
+      oheight = original.outerHeight();
+      cheight = copy.outerHeight();
+      height = (oheight > cheight ? oheight : cheight);
+      original.css('min-height', height+'px');
+      copy.css('min-height', height+'px');
   }
 
 });

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -52,7 +52,7 @@ $(document).ready(function() {
           tx = self.find('th, td');
 
       tx.each(function () {
-        var height = $(this).outerHeight(true);
+        var height = $(this).height;
         heights[index] = heights[index] || 0;
         if (height > heights[index]) heights[index] = height;
         $(this).css('height', heights[index]+'px');

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -55,12 +55,13 @@ $(document).ready(function() {
         var height = $(this).outerHeight(true);
         heights[index] = heights[index] || 0;
         if (height > heights[index]) heights[index] = height;
+        $(this).css('height', heights[index]+'px');
       });
 
     });
 
     tr_copy.each(function (index) {
-      $(this).height(heights[index]);
+      $(this).css('height', heights[index]+'px');
     });
   }
 

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -43,25 +43,12 @@ $(document).ready(function() {
 	}
 
   function setCellHeights(original, copy) {
-    var tr = original.find('tr'),
-        tr_copy = copy.find('tr'),
-        heights = [];
-
-    tr.each(function (index) {
-      var self = $(this),
-          tx = self.find('th, td');
-
-      tx.each(function () {
-        var height = $(this).height;
-        heights[index] = heights[index] || 0;
-        if (height > heights[index]) heights[index] = height;
-        $(this).css('height', heights[index]+'px');
-      });
-
-    });
-
-    tr_copy.each(function (index) {
-      $(this).css('height', heights[index]+'px');
+    $('tr', original).each(function(index){
+      oheight = $(this).height();
+      cheight = $('tr:eq('+index+')', copy).height();
+      height = (oheight > cheight ? oheight : cheight);
+      $('th,td', original).css('height', height+'px');
+      $('th,td', copy).css('height', height+'px');
     });
   }
 


### PR DESCRIPTION
Calling $(this).height(height[index]) doesn't do anything as height() doesn't accept any arguments. I switched it to $(this).css('height', heights[index]+'px'); for the original and the copy so that both rows match in height when the pinning takes place.
