### PR TITLE
Add trigger hook for responsive tables

### DIFF
--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -14,6 +14,8 @@ $(document).ready(function() {
         unsplitTable($(element));
       });
     }
+    
+    $(window).trigger('responsiveTables.postDraw');
   };
    
   $(window).load(updateTables);


### PR DESCRIPTION
Externalises a hook when the tables get split to rebind any listeners you may have on the table.

They currently get canned.
