### PR TITLE
Clean-up, delint, performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
 <!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
 <head>
   <meta charset="utf-8" />
-  
+
   <!-- Set the viewport width to device width for mobile -->
   <meta name="viewport" content="width=device-width" />
-  
+
   <title>Responsive Tables by ZURB</title>
-  
+
   <!-- Included CSS Files -->
   <!-- Combine and Compress These CSS Files -->
   <link rel="stylesheet" href="stylesheets/globals.css">
@@ -25,15 +25,15 @@
   <link rel="stylesheet" href="stylesheets/mobile.css">
   <!-- End Combine and Compress These CSS Files -->
   <link rel="stylesheet" href="stylesheets/app.css">
-	<link rel="stylesheet" href="responsive-tables.css">
-	<script src="javascripts/jquery.min.js"></script>
-	<script src="responsive-tables.js"></script>
-	
+  <link rel="stylesheet" href="responsive-tables.css">
+  <script src="javascripts/jquery.min.js"></script>
+  <script src="responsive-tables.js"></script>
+
   <!--[if lt IE 9]>
   <link rel="stylesheet" href="stylesheets/ie.css">
   <![endif]-->
-  
-  
+
+
   <!-- IE Fix for HTML5 Tags -->
   <!--[if lt IE 9]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -41,262 +41,255 @@
 </head>
 
 <body>
-	<!-- container -->
-	<div class="container">
+  <!-- container -->
+  <div class="container">
 
-		<div class="row">
-			<div class="twelve columns">
-				<h1>Responsive Tables</h1>
-				<h4 class="subhead">A CSS/JS solution for tables that allows them to shrink on small devices without sacrificing the value of tables, comparison of columns.</h4>
-				
-		    <p>Our solution for responsive tables requires two included files (both linked on this page): responsive-tables.css and responsive-tables.js.</p>
-		    <p>The JS will help us create some new elements on small devices, so we don't have to modify our table markup on the page. The CSS applies the requisite positioning and overflow styles to make the new elements work.</p>
-				    <pre>
+    <div class="row">
+      <div class="twelve columns">
+        <h1>Responsive Tables</h1>
+        <h4 class="subhead">A CSS/JS solution for tables that allows them to shrink on small devices without sacrificing the value of tables, comparison of columns.</h4>
+
+        <p>Our solution for responsive tables requires two included files (both linked on this page): responsive-tables.css and responsive-tables.js.</p>
+        <p>The JS will help us create some new elements on small devices, so we don't have to modify our table markup on the page. The CSS applies the requisite positioning and overflow styles to make the new elements work.</p>
+            <pre>
 /* Attach the Table CSS and Javascript */
 <span style="color: #6ab825; font-weight: normal">&lt;link</span> <span style="color: #bbbbbb">rel=</span><span style="color: #ed9d13">"stylesheet"</span> <span style="color: #bbbbbb">href=</span><span style="color: #ed9d13">"responsive-tables.css"</span><span style="color: #6ab825; font-weight: normal">&gt;</span>
 <span style="color: #6ab825; font-weight: normal">&lt;script</span> <span style="color: #bbbbbb">src=</span><span style="color: #ed9d13">"stylesheet"</span> <span style="color: #bbbbbb">href=</span><span style="color: #ed9d13">"responsive-tables.js"</span><span style="color: #6ab825; font-weight: normal">&gt;</span><span style="color: #6ab825; font-weight: normal">&lt;/script&gt;</span></pre>
-				
-				<hr />
-				
-    		<h5>Small Word Table</h5>
-				<table class="responsive">
-    				
-					<tr>
-						<th>Header 1</th>
-						<th>Header 2</th>
-						<th>Header 3</th>
-						<th>Header 4</th>
-						<th>Header 5</th>
-						<th>Header 6</th>
-						<th>Header 7</th>
-						<th>Header 8</th>
-					</tr>
-					<tr>
-						<td>row 1, cell 1</td>
-						<td>row 1, cell 2</td>
-						<td>row 1, cell 3</td>
-						<td>row 1, cell 4</td>
-						<td>row 1, cell 5</td>
-						<td>row 1, cell 6</td>
-						<td>row 1, cell 7</td>
-						<td>row 1, cell 8</td>
-					</tr>
-					<tr>
-						<td>row 2, cell 1</td>
-						<td>row 2, cell 2</td>
-						<td>row 2, cell 3</td>
-						<td>row 2, cell 4</td>
-						<td>row 2, cell 5</td>
-						<td>row 2, cell 6</td>
-						<td>row 2, cell 7</td>
-						<td>row 2, cell 8</td>
-					</tr>
-					<tr>
-						<td>row 3, cell 1</td>
-						<td>row 3, cell 2</td>
-						<td>row 3, cell 3</td>
-						<td>row 3, cell 4</td>
-						<td>row 3, cell 5</td>
-						<td>row 3, cell 6</td>
-						<td>row 3, cell 7</td>
-						<td>row 3, cell 8</td>
-					</tr>
-					<tr>
-						<td>row 4, cell 1</td>
-						<td>row 4, cell 2</td>
-						<td>row 4, cell 3</td>
-						<td>row 4, cell 4</td>
-						<td>row 4, cell 5</td>
-						<td>row 4, cell 6</td>
-						<td>row 4, cell 7</td>
-						<td>row 4, cell 8</td>
-					</tr>
-    					
+
+        <hr />
+
+        <h5>Small Word Table</h5>
+        <table class="responsive">
+          <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+            <th>Header 4</th>
+            <th>Header 5</th>
+            <th>Header 6</th>
+            <th>Header 7</th>
+            <th>Header 8</th>
+          </tr>
+          <tr>
+            <td>row 1, cell 1</td>
+            <td>row 1, cell 2</td>
+            <td>row 1, cell 3</td>
+            <td>row 1, cell 4</td>
+            <td>row 1, cell 5</td>
+            <td>row 1, cell 6</td>
+            <td>row 1, cell 7</td>
+            <td>row 1, cell 8</td>
+          </tr>
+          <tr>
+            <td>row 2, cell 1</td>
+            <td>row 2, cell 2</td>
+            <td>row 2, cell 3</td>
+            <td>row 2, cell 4</td>
+            <td>row 2, cell 5</td>
+            <td>row 2, cell 6</td>
+            <td>row 2, cell 7</td>
+            <td>row 2, cell 8</td>
+          </tr>
+          <tr>
+            <td>row 3, cell 1</td>
+            <td>row 3, cell 2</td>
+            <td>row 3, cell 3</td>
+            <td>row 3, cell 4</td>
+            <td>row 3, cell 5</td>
+            <td>row 3, cell 6</td>
+            <td>row 3, cell 7</td>
+            <td>row 3, cell 8</td>
+          </tr>
+          <tr>
+            <td>row 4, cell 1</td>
+            <td>row 4, cell 2</td>
+            <td>row 4, cell 3</td>
+            <td>row 4, cell 4</td>
+            <td>row 4, cell 5</td>
+            <td>row 4, cell 6</td>
+            <td>row 4, cell 7</td>
+            <td>row 4, cell 8</td>
+          </tr>
         </table>
-        
+
         <div class="row">
-    		  <div class="six columns">
-    		    <p>In most cases, tables like this are okay at smaller sizes (since they'll break on every small word). However, with this many columns a very small device like a phone would still be a problem.</p>
-    		  </div>
-    		  <div class="six columns">
-    		    <p>By attaching a class of <strong>.responsive</strong> to the table, our JS/CSS will kick in.</p>
-    		  </div>
-    		</div>
-    		
-    		<pre>
+          <div class="six columns">
+            <p>In most cases, tables like this are okay at smaller sizes (since they'll break on every small word). However, with this many columns a very small device like a phone would still be a problem.</p>
+          </div>
+          <div class="six columns">
+            <p>By attaching a class of <strong>.responsive</strong> to the table, our JS/CSS will kick in.</p>
+          </div>
+        </div>
+
+        <pre>
 /* Put the responsive class on the table */
 <span style="color: #6ab825; font-weight: normal">&lt;table</span> <span style="color: #bbbbbb">class=</span><span style="color: #ed9d13">"responsive"</span><span style="color: #6ab825; font-weight: normal">&gt;</span>
   <span style="color: #6ab825; font-weight: normal">&lt;tr&gt;</span> …
 </pre>
-  
-    		
-    		<hr />
 
-        
-    		<h5>Larger Content Table</h5>
+
+        <hr />
+
+
+        <h5>Larger Content Table</h5>
         <table class="responsive">
-  				<tbody>
-  				  <tr>
-      				<th>Perk</th>
-      				<th>Description</th>
-      				<th>ID</th>
-      				<th>Skill Req</th>
-      				<th>Perk Req</th>
-    				</tr>
-    				<tr>
-      				<td>Steel Smithing</td>
-      				<td>Can create Steel armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb40d</td>
-      				<td></td>
-      				<td></td>
-    				</tr>
-    				<tr>
-      				<td>Arcane Blacksmith</td>
-      				<td>You can improve magical weapons and armor.</td>
-      				<td><span style="font-size: x-small" class="idref">0005218e</span></td>
-      				<td>60 Smithing</td>
-      				<td>Steel Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Dwarven Smithing</td>
-      				<td>Can create Dwarven armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb40e</td>
-      				<td>30 Smithing</td>
-      				<td>Steel Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Orcish Smithing</td>
-      				<td>Can create Orcish armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb410</td>
-      				<td>50 Smithing</td>
-      				<td>Dwarven Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Ebony Smithing</td>
-      				<td>Can create Ebony armor and weapons at forges</a>, and improve them twice as much.</td>
-      				<td>000cb412</td>
-      				<td>80 Smithing</td>
-      				<td>Orcish Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Daedric Smithing</td>
-      				<td>Can create Daedric armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb413</span></td>
-      				<td>90 Smithing</td>
-      				<td>Ebony Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Elven Smithing</td>
-      				<td>Can create Elven armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb40f</td>
-      				<td>30 Smithing</td>
-      				<td>Steel Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Advanced Armors</td>
-      				<td>Can create Scaled and Plate armor at forges, and improve them twice as much.
-      				<td>000cb414</td>
-      				<td>50 Smithing</td>
-      				<td>Elven Smithing</td>
-    				</tr>
-    				<tr>
-      				<td>Glass Smithing</td>
-      				<td>Can create Glass armor and weapons at forges, and improve them twice as much.</td>
-      				<td>000cb411</td>
-      				<td>70 Smithing</td>
-      				<td>Advanced Armors</td>
-    				</tr>
-    				<tr>
-      				<td>Dragon Armor</td>
-      				<td>Can create Dragon armor at forges, and improve them twice as much.</td>
-      				<td>00052190</td>
-      				<td>100 Smithing</td>
-      				<td>Daedric Smithing or Glass Smithing</td>
-    				</tr>
-				  </tbody>
-				</table>
-				
-    		<div class="row">
-    		  <div class="six columns">
-    		    <p>The effect is even more pronounced on a table like this one, where we detail how to craft different armor types in Skyrim (we're nerds, okay).</p>
-    		  </div>
-    		  <div class="six columns">
-    		    <p>Notice on a small device how we maintain the left column when it has so much content.</p>
-    		  </div>
-    		</div>
-    		
-    		<hr />
-    		
-    		<h5>Very Long 1st Cell Content</h5>
-				
-				<table class="responsive">
-				
-					<tr>
-						<th>Header 1</th>
-						<th>Header 2</th>
-						<th>Header 3</th>
-						<th>Header 4</th>
-						<th>Header 5</th>
-						<th>Header 6</th>
-						<th>Header 7</th>
-						<th>Header 8</th>
-					</tr>
-					<tr>
-						<td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
-						<td>row 1, cell 2</td>
-						<td>row 1, cell 3</td>
-						<td>row 1, cell 4</td>
-						<td>row 1, cell 5</td>
-						<td>row 1, cell 6</td>
-						<td>row 1, cell 7</td>
-						<td>row 1, cell 8</td>
-					</tr>
-					<tr>
-						<td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
-						<td>row 2, cell 2</td>
-						<td>row 2, cell 3</td>
-						<td>row 2, cell 4</td>
-						<td>row 2, cell 5</td>
-						<td>row 2, cell 6</td>
-						<td>row 2, cell 7</td>
-						<td>row 2, cell 8</td>
-					</tr>
-					<tr>
-						<td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
-						<td>row 3, cell 2</td>
-						<td>row 3, cell 3</td>
-						<td>row 3, cell 4</td>
-						<td>row 3, cell 5</td>
-						<td>row 3, cell 6</td>
-						<td>row 3, cell 7</td>
-						<td>row 3, cell 8</td>
-					</tr>
-					<tr>
-						<td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
-						<td>row 4, cell 2</td>
-						<td>row 4, cell 3</td>
-						<td>row 4, cell 4</td>
-						<td>row 4, cell 5</td>
-						<td>row 4, cell 6</td>
-						<td>row 4, cell 7</td>
-						<td>row 4, cell 8</td>
-					</tr>
-					
-				</table>
-    		<div class="row">
-    		  <div class="six columns">
-    		    <p>Finally, in this example you'll see how this works for very long first-cell content. Both the first cell and the remaining cells are independently scrollable on small devices.</p>
-    		  </div>
-    		  <div class="six columns">
-    		    <p>We do this so we can correctly predict the height of the cells for both the pinned columns and the rest of the columns.</p>
-    		  </div>
-			</div>
-		</div>
+          <tbody>
+            <tr>
+              <th>Perk</th>
+              <th>Description</th>
+              <th>ID</th>
+              <th>Skill Req</th>
+              <th>Perk Req</th>
+            </tr>
+            <tr>
+              <td>Steel Smithing</td>
+              <td>Can create Steel armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb40d</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>Arcane Blacksmith</td>
+              <td>You can improve magical weapons and armor.</td>
+              <td><span style="font-size: x-small" class="idref">0005218e</span></td>
+              <td>60 Smithing</td>
+              <td>Steel Smithing</td>
+            </tr>
+            <tr>
+              <td>Dwarven Smithing</td>
+              <td>Can create Dwarven armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb40e</td>
+              <td>30 Smithing</td>
+              <td>Steel Smithing</td>
+            </tr>
+            <tr>
+              <td>Orcish Smithing</td>
+              <td>Can create Orcish armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb410</td>
+              <td>50 Smithing</td>
+              <td>Dwarven Smithing</td>
+            </tr>
+            <tr>
+              <td>Ebony Smithing</td>
+              <td>Can create Ebony armor and weapons at forges</a>, and improve them twice as much.</td>
+              <td>000cb412</td>
+              <td>80 Smithing</td>
+              <td>Orcish Smithing</td>
+            </tr>
+            <tr>
+              <td>Daedric Smithing</td>
+              <td>Can create Daedric armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb413</span></td>
+              <td>90 Smithing</td>
+              <td>Ebony Smithing</td>
+            </tr>
+            <tr>
+              <td>Elven Smithing</td>
+              <td>Can create Elven armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb40f</td>
+              <td>30 Smithing</td>
+              <td>Steel Smithing</td>
+            </tr>
+            <tr>
+              <td>Advanced Armors</td>
+              <td>Can create Scaled and Plate armor at forges, and improve them twice as much.
+              <td>000cb414</td>
+              <td>50 Smithing</td>
+              <td>Elven Smithing</td>
+            </tr>
+            <tr>
+              <td>Glass Smithing</td>
+              <td>Can create Glass armor and weapons at forges, and improve them twice as much.</td>
+              <td>000cb411</td>
+              <td>70 Smithing</td>
+              <td>Advanced Armors</td>
+            </tr>
+            <tr>
+              <td>Dragon Armor</td>
+              <td>Can create Dragon armor at forges, and improve them twice as much.</td>
+              <td>00052190</td>
+              <td>100 Smithing</td>
+              <td>Daedric Smithing or Glass Smithing</td>
+            </tr>
+          </tbody>
+        </table>
 
+        <div class="row">
+          <div class="six columns">
+            <p>The effect is even more pronounced on a table like this one, where we detail how to craft different armor types in Skyrim (we're nerds, okay).</p>
+          </div>
+          <div class="six columns">
+            <p>Notice on a small device how we maintain the left column when it has so much content.</p>
+          </div>
+        </div>
 
+        <hr />
 
-	</div>
+        <h5>Very Long 1st Cell Content</h5>
 
+        <table class="responsive">
+          <tr>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+            <th>Header 4</th>
+            <th>Header 5</th>
+            <th>Header 6</th>
+            <th>Header 7</th>
+            <th>Header 8</th>
+          </tr>
+          <tr>
+            <td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
+            <td>row 1, cell 2</td>
+            <td>row 1, cell 3</td>
+            <td>row 1, cell 4</td>
+            <td>row 1, cell 5</td>
+            <td>row 1, cell 6</td>
+            <td>row 1, cell 7</td>
+            <td>row 1, cell 8</td>
+          </tr>
+          <tr>
+            <td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
+            <td>row 2, cell 2</td>
+            <td>row 2, cell 3</td>
+            <td>row 2, cell 4</td>
+            <td>row 2, cell 5</td>
+            <td>row 2, cell 6</td>
+            <td>row 2, cell 7</td>
+            <td>row 2, cell 8</td>
+          </tr>
+          <tr>
+            <td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
+            <td>row 3, cell 2</td>
+            <td>row 3, cell 3</td>
+            <td>row 3, cell 4</td>
+            <td>row 3, cell 5</td>
+            <td>row 3, cell 6</td>
+            <td>row 3, cell 7</td>
+            <td>row 3, cell 8</td>
+          </tr>
+          <tr>
+            <td>Ham pork leberkas bresaola, brisket t-bone filet mignon hamburger salami andouille short loin sausage.</td>
+            <td>row 4, cell 2</td>
+            <td>row 4, cell 3</td>
+            <td>row 4, cell 4</td>
+            <td>row 4, cell 5</td>
+            <td>row 4, cell 6</td>
+            <td>row 4, cell 7</td>
+            <td>row 4, cell 8</td>
+          </tr>
+        </table>
+
+        <div class="row">
+          <div class="six columns">
+            <p>Finally, in this example you'll see how this works for very long first-cell content. Both the first cell and the remaining cells are independently scrollable on small devices.</p>
+          </div>
+          <div class="six columns">
+            <p>We do this so we can correctly predict the height of the cells for both the pinned columns and the rest of the columns.</p>
+          </div>
+      </div>
+    </div>
+  </div>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
   <link rel="stylesheet" href="stylesheets/ie.css">
   <![endif]-->
 
-
   <!-- IE Fix for HTML5 Tags -->
   <!--[if lt IE 9]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -41,7 +40,6 @@
 </head>
 
 <body>
-  <!-- container -->
   <div class="container">
 
     <div class="row">
@@ -127,9 +125,7 @@
   <span style="color: #6ab825; font-weight: normal">&lt;tr&gt;</span> …
 </pre>
 
-
         <hr />
-
 
         <h5>Larger Content Table</h5>
         <table class="responsive">
@@ -287,7 +283,7 @@
           <div class="six columns">
             <p>We do this so we can correctly predict the height of the cells for both the pinned columns and the rest of the columns.</p>
           </div>
-      </div>
+        </div>
     </div>
   </div>
 

--- a/responsive-tables.css
+++ b/responsive-tables.css
@@ -1,28 +1,6 @@
 /* Foundation v2.1.4 http://foundation.zurb.com */
 /* Artfully masterminded by ZURB  */
 
-/* --------------------------------------------------
-   Table of Contents
------------------------------------------------------
-:: Shared Styles
-:: Page Name 1
-:: Page Name 2
-*/
-
-/* -----------------------------------------
-   Shared Styles
------------------------------------------ */
-
-/*table th {
-  font-weight: bold;
-}
-
-table td,
-table th {
-  padding: 9px 10px;
-  text-align: left;
-}*/
-
 /* Mobile */
 @media only screen and (max-width: 767px) {
 

--- a/responsive-tables.css
+++ b/responsive-tables.css
@@ -1,7 +1,7 @@
 /* Foundation v2.1.4 http://foundation.zurb.com */
 /* Artfully masterminded by ZURB  */
 
-/* -------------------------------------------------- 
+/* --------------------------------------------------
    Table of Contents
 -----------------------------------------------------
 :: Shared Styles
@@ -9,30 +9,81 @@
 :: Page Name 2
 */
 
-
 /* -----------------------------------------
    Shared Styles
 ----------------------------------------- */
 
-table th { font-weight: bold; }
-table td, table th { padding: 9px 10px; text-align: left; }
+/*table th {
+  font-weight: bold;
+}
+
+table td,
+table th {
+  padding: 9px 10px;
+  text-align: left;
+}*/
 
 /* Mobile */
 @media only screen and (max-width: 767px) {
-	
-	table.responsive { margin-bottom: 0; }
-	
-	.pinned { position: absolute; left: 0; top: 0; background: #fff; width: 35%; overflow: hidden; overflow-x: scroll; border-right: 1px solid #ccc; border-left: 1px solid #ccc; }
-	.pinned table { border-right: none; border-left: none; width: 100%; }
-	.pinned table th, .pinned table td { white-space: nowrap; }
-	.pinned td:last-child { border-bottom: 0; }
-	
-	div.table-wrapper { position: relative; margin-bottom: 20px; overflow: hidden; border-right: 1px solid #ccc; }
-	div.table-wrapper div.scrollable { margin-left: 35%; }
-	div.table-wrapper div.scrollable { overflow: scroll; overflow-y: hidden; }	
-	
-	table.responsive td, table.responsive th { position: relative; white-space: nowrap; overflow: hidden; }
-	table.responsive th:first-child, table.responsive td:first-child, table.responsive td:first-child, table.responsive.pinned td { display: none; }
-	
-	
+
+  table.responsive {
+    margin-bottom: 0;
+  }
+
+  .pinned {
+    position: absolute;
+    left: 0;
+    top: 0;
+    background: #fff;
+    width: 35%;
+    overflow: hidden;
+    overflow-x: scroll;
+    border-right: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+  }
+
+  .pinned table {
+    border-right: none;
+    border-left: none;
+    width: 100%;
+  }
+
+  .pinned table th,
+  .pinned table td {
+    white-space: nowrap;
+  }
+
+  .pinned td:last-child {
+    border-bottom: 0;
+  }
+
+  .table-wrapper {
+    position: relative;
+    margin-bottom: 20px;
+    overflow: hidden;
+    border-right: 1px solid #ccc;
+  }
+
+  .table-wrapper .scrollable {
+    margin-left: 35%;
+  }
+
+  .table-wrapper .scrollable {
+    overflow: scroll;
+    overflow-y: hidden;
+  }
+
+  table.responsive td,
+  table.responsive th {
+    position: relative;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  table.responsive th:first-child,
+  table.responsive td:first-child,
+  table.responsive td:first-child,
+  table.responsive.pinned td {
+    display: none;
+  }
 }

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -55,7 +55,9 @@
           splitTable($(element));
         });
         return true;
-      } else if (switched && ($window.width() > 767)) {
+      }
+
+      if (switched && $window.width() > 767) {
         switched = false;
         $responsiveTable.each(function (i, element) {
           unsplitTable($(element));
@@ -64,6 +66,7 @@
     }
 
     $window.on('load', updateTables);
+    // @todo Debounce this.
     $window.on('resize', updateTables);
     $window.on('redraw', function () {
       switched = false;

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -1,67 +1,74 @@
-$(document).ready(function() {
-  var switched = false;
-  var updateTables = function() {
-    if (($(window).width() < 767) && !switched ){
-      switched = true;
-      $("table.responsive").each(function(i, element) {
-        splitTable($(element));
-      });
-      return true;
-    }
-    else if (switched && ($(window).width() > 767)) {
-      switched = false;
-      $("table.responsive").each(function(i, element) {
-        unsplitTable($(element));
-      });
-    }
-  };
-   
-  $(window).load(updateTables);
-  $(window).on("redraw",function(){switched=false;updateTables();}); // An event to listen for
-  $(window).on("resize", updateTables);
-   
-	
-	function splitTable(original)
-	{
-		original.wrap("<div class='table-wrapper' />");
-		
-		var copy = original.clone();
-		copy.find("td:not(:first-child), th:not(:first-child)").css("display", "none");
-		copy.removeClass("responsive");
-		
-		original.closest(".table-wrapper").append(copy);
-		copy.wrap("<div class='pinned' />");
-		original.wrap("<div class='scrollable' />");
+(function ($, window) {
+  // DOM Ready.
+  $(function () {
+    var $window = $(window);
+    var $responsiveTable = $('table.responsive');
+    var switched = false;
 
-    setCellHeights(original, copy);
-	}
-	
-	function unsplitTable(original) {
-    original.closest(".table-wrapper").find(".pinned").remove();
-    original.unwrap();
-    original.unwrap();
-	}
-
-  function setCellHeights(original, copy) {
-    var tr = original.find('tr'),
+    function setCellHeights(original, copy) {
+      var tr = original.find('tr'),
         tr_copy = copy.find('tr'),
         heights = [];
 
-    tr.each(function (index) {
-      var self = $(this),
+      tr.each(function (index) {
+        var self = $(this),
           tx = self.find('th, td');
 
-      tx.each(function () {
-        var height = $(this).outerHeight(true);
-        heights[index] = heights[index] || 0;
-        if (height > heights[index]) heights[index] = height;
+        tx.each(function () {
+          var height = $(this).outerHeight(true);
+          heights[index] = heights[index] || 0;
+          if (height > heights[index]) {
+            heights[index] = height;
+          }
+        });
       });
 
-    });
+      tr_copy.each(function (index) {
+        $(this).height(heights[index]);
+      });
+    }
 
-    tr_copy.each(function (index) {
-      $(this).height(heights[index]);
-    });
-  }
+    function splitTable(original) {
+      original.wrap('<div class="table-wrapper" />');
 
-});
+      var copy = original.clone();
+      copy.find('td:not(:first-child), th:not(:first-child)').css('display', 'none');
+      copy.removeClass("responsive");
+
+      original.closest('.table-wrapper').append(copy);
+      copy.wrap('<div class="pinned" />');
+      original.wrap('<div class="scrollable" />');
+
+      setCellHeights(original, copy);
+    }
+
+    function unsplitTable(original) {
+      original.closest('.table-wrapper').find('.pinned').remove();
+      original.unwrap();
+      original.unwrap();
+    }
+
+    function updateTables() {
+      if ($window.width() < 767 && !switched) {
+        switched = true;
+        $responsiveTable.each(function (i, element) {
+          splitTable($(element));
+        });
+        return true;
+      } else if (switched && ($window.width() > 767)) {
+        switched = false;
+        $responsiveTable.each(function (i, element) {
+          unsplitTable($(element));
+        });
+      }
+    }
+
+    $window.on('load', updateTables);
+    $window.on('resize', updateTables);
+    $window.on('redraw', function () {
+      switched = false;
+      updateTables();
+    });
+  });
+
+})(jQuery, window);

--- a/stylesheets/app.css
+++ b/stylesheets/app.css
@@ -1,37 +1,64 @@
 /* Artfully masterminded by ZURB  */
 
-/* -------------------------------------------------- 
+/* --------------------------------------------------
    Table of Contents
 -----------------------------------------------------
+:: Base Styles
 :: Shared Styles
-:: Page Name 1
-:: Page Name 2
 */
 
+/* -----------------------------------------
+   Base Styles
+----------------------------------------- */
+
+body {
+  background: #f4f4f4;
+}
+
+p {
+  color: #999;
+}
+
+h1 {
+  margin: 20px 0 0;
+}
+
+pre {
+  border-radius: 5px;
+  margin: 0;
+  display: block;
+  font: 11px Monaco, monospace !important;
+  padding: 15px;
+  background-color: #1C1C1C;
+  overflow: auto;
+  color: #D0D0D0;
+  line-height: 125%;
+  margin-bottom: 30px;
+}
+
+table th {
+  font-weight: bold;
+}
+
+table td,
+table th {
+  padding: 9px 10px;
+  text-align: left;
+}
 
 /* -----------------------------------------
    Shared Styles
 ----------------------------------------- */
 
-  body { background: #f4f4f4; }
-  .container { max-width: 740px; box-shadow: 0px 2px 5px rgba(0,0,0,0.25); background: #fff; margin: 0 auto; }
-  
-  p { color: #999; }
-  
-  h1 { margin: 20px 0 0; }
-  h4.subhead { font-weight: lighter; color: #777; margin-bottom: 20px; }
-  
-  pre { -moz-border-radius: 5px; border-radius: 5px; -webkit-border-radius: 5px; margin: 0; display: block; font: 11px Monaco, monospace !important; padding: 15px; background-color: #1C1C1C; overflow: auto; color: #D0D0D0; line-height: 125%; margin-bottom: 30px; }
+.container {
+  max-width: 740px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.25);
+  background: #fff;
+  margin: 0 auto;
+}
 
-/* -----------------------------------------
-   Page Name 1
------------------------------------------ */
-
-
-
-
-/* -----------------------------------------
-   Page Name 2
------------------------------------------ */
-
-
+h4.subhead {
+  font-weight: lighter;
+  color: #777;
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
This may look unwieldy but it's not terribly exhaustive clean-up.
- Delinted most of the JavaScript.
- Wrapped the JS in a closure for better no-conflict support.
- Made all tabs spacing into 2 spaces for consistency.
- Removed a few overqualified CSS selectors (May be better to BEMize these to avoid conflicts)
- Commented out the CSS generic table styles, probably should move that to a different CSS for the demo presentation only?
- Moved the events to the bottom of the JS.
- Made the function declarations use all the same declaration style.
