### PR TITLE
Fixed incompatibility with jQuery 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# responsive-tables
+Tables that work responsively on small devices.
+This fork was created in order to fix the incompatibility of this project with jQuery 3.x.

--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(function() {
   var switched = false;
   var updateTables = function() {
     if (($(window).width() < 767) && !switched ){
@@ -16,31 +16,29 @@ $(document).ready(function() {
     }
   };
    
-  $(window).load(updateTables);
+  $(window).on('load', updateTables);
   $(window).on("redraw",function(){switched=false;updateTables();}); // An event to listen for
-  $(window).on("resize", updateTables);
-   
-	
-	function splitTable(original)
-	{
-		original.wrap("<div class='table-wrapper' />");
-		
-		var copy = original.clone();
-		copy.find("td:not(:first-child), th:not(:first-child)").css("display", "none");
-		copy.removeClass("responsive");
-		
-		original.closest(".table-wrapper").append(copy);
-		copy.wrap("<div class='pinned' />");
-		original.wrap("<div class='scrollable' />");
+  $(window).on("resize", updateTables);   
+  
+  function splitTable(original) {
+    original.wrap("<div class='table-wrapper' />");
+    
+    var copy = original.clone();
+    copy.find("td:not(:first-child), th:not(:first-child)").css("display", "none");
+    copy.removeClass("responsive");
+    
+    original.closest(".table-wrapper").append(copy);
+    copy.wrap("<div class='pinned' />");
+    original.wrap("<div class='scrollable' />");
 
     setCellHeights(original, copy);
-	}
-	
-	function unsplitTable(original) {
+  }
+  
+  function unsplitTable(original) {
     original.closest(".table-wrapper").find(".pinned").remove();
     original.unwrap();
     original.unwrap();
-	}
+  }
 
   function setCellHeights(original, copy) {
     var tr = original.find('tr'),
@@ -63,5 +61,4 @@ $(document).ready(function() {
       $(this).height(heights[index]);
     });
   }
-
 });


### PR DESCRIPTION
Hello.

This pull request is in response to [Issue 42, newer jquery version](https://github.com/zurb/responsive-tables/issues/42).

The issue was the use of the `.load()` event, [which has been removed from jQuery 3](https://jquery.com/upgrade-guide/3.0/#event). I updated this to use the `.on()` method.

While in there, I also updated the document-ready handler, as `$(document).ready(fn)` [has been deprecated](https://jquery.com/upgrade-guide/3.0/#deprecated-document-ready-handlers-other-than-jquery-function). I updated this to use the `jQuery(function)` syntax.