### PR TITLE
Update responsive-tables.js

### DIFF
--- a/responsive-tables.js
+++ b/responsive-tables.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
     }
   };
    
-  $(window).load(updateTables);
+  updateTables();
   $(window).on("redraw",function(){switched=false;updateTables();}); // An event to listen for
   $(window).on("resize", updateTables);
    


### PR DESCRIPTION
jQuery.load(updateTables) fired an exception »Uncaught TypeError: a.indexOf is not a function«.  Probably the function updateTables should only be initially executed.